### PR TITLE
Fix persistent Operator Registration Error from stale validation state

### DIFF
--- a/store/operatorSlice/index.ts
+++ b/store/operatorSlice/index.ts
@@ -942,10 +942,17 @@ const operatorSlice = createSlice({
       const operator = localStorage.getItem("Fuse-operator");
       const isAuthenticated = localStorage.getItem("Fuse-isOperatorAuthenticated");
       const operatorContactDetail = localStorage.getItem("Fuse-operatorContactDetail");
+      const isAuthenticatedHydrated = isAuthenticated ? JSON.parse(isAuthenticated) : false;
       state.isOperatorExist = isOperatorExist ? JSON.parse(isOperatorExist) : false;
-      state.isValidated = isValidated ? JSON.parse(isValidated) : false;
       state.operator = operator ? JSON.parse(operator) : initOperator;
-      state.isAuthenticated = isAuthenticated ? JSON.parse(isAuthenticated) : false;
+      state.isAuthenticated = isAuthenticatedHydrated;
+      // A persisted "validated" flag is only trustworthy when the user is also
+      // authenticated. Without authentication it is a stale intermediate state (the
+      // user signed the EOA validation message but never finished registering).
+      // Restoring it on reload makes useOperatorRegistration skip the signature step,
+      // stranding the user on the Operator Registration Error screen, so reset it
+      // unless authenticated.
+      state.isValidated = isAuthenticatedHydrated && isValidated ? JSON.parse(isValidated) : false;
       state.operatorContactDetail = operatorContactDetail ? JSON.parse(operatorContactDetail) : initOperatorContactDetail;
       state.isHydrated = true;
     }


### PR DESCRIPTION
setHydrate restored Fuse-isValidated=true from localStorage even when the user was not authenticated. This happens whenever someone signs the EOA validation message but never finishes registering (abandons the contact form or createOperator fails).

On the next visit the wallet auto-reconnects, but useOperatorRegistration gates the signature prompt on !isValidated, so it skips signing and never runs validateOperator/fetchOperator. OperatorRegistrationSection then falls through every branch to the OperatorRegistrationError fallback, leaving the user permanently stuck. Clearing the browser cache does not help because localStorage is not cache, so the stale flag survives.

Only restore isValidated when the user is also authenticated. Otherwise the flow re-prompts the signature on reload and routes the user correctly (to the dashboard or the registration form).